### PR TITLE
Fix extension definition

### DIFF
--- a/xExtension-KeepFolderState/extension.php
+++ b/xExtension-KeepFolderState/extension.php
@@ -1,6 +1,16 @@
 <?php
 
 class KeepFolderStateExtension extends Minz_Extension {
+    public function install() {
+        return true;
+    }
+
+    public function uninstall() {
+        return true;
+    }
+
+    public function handleConfigureAction() {
+    }
 
     public function init() {
         Minz_View::appendScript($this->getFileUrl('jquerymin.js', 'js'),'','','');


### PR DESCRIPTION
Before, extension was missing the definition of mandatory methods.
At the moment, it's not a problem because the coding guidelines are not
enforced by the code. But in the future, it will break.
Now, extension have all mandatory method definitions.