### PR TITLE
Fix extension definition

### DIFF
--- a/xExtension-FixedNavMenu/extension.php
+++ b/xExtension-FixedNavMenu/extension.php
@@ -1,10 +1,20 @@
 <?php
 
 class FixedNavMenuExtension extends Minz_Extension {
+    public function install() {
+        return true;
+    }
+
+    public function uninstall() {
+        return true;
+    }
+
+    public function handleConfigureAction() {
+    }
 
     public function init() {
         Minz_View::appendStyle($this->getFileUrl('style.css', 'css'));
-        
+
         Minz_View::appendScript($this->getFileUrl('jquerymin.js', 'js'),'','','');
         Minz_View::appendScript($this->getFileUrl('script.js', 'js'),'','','');       
     }


### PR DESCRIPTION
Before, extension was missing the definition of mandatory methods.
At the moment, it's not a problem because the coding guidelines are not
enforced by the code. But in the future, it will break.
Now, extension have all mandatory method definitions.